### PR TITLE
fix(deployment): Remove mounter resource request and pin alpine version

### DIFF
--- a/charts/microservice-chart/templates/beta-deployment.yaml
+++ b/charts/microservice-chart/templates/beta-deployment.yaml
@@ -102,15 +102,12 @@ spec:
         - name: crt-mounter
           securityContext:
             allowPrivilegeEscalation: false
-          image: alpine:latest
+          image: alpine:3.16.1@sha256:9b2a28eb47540823042a2ba401386845089bb7b62a9637d55816132c4c3c36eb
           command: ['tail', '-f', '/dev/null']
           resources:
-            requests:
+            limits:
               memory: 16Mi
               cpu: 50m
-            limits:
-              memory: 32Mi
-              cpu: 100m
           volumeMounts:
             - name: secrets-store-inline-crt
               mountPath: "/mnt/secrets-store-crt"

--- a/charts/microservice-chart/templates/deployments.yaml
+++ b/charts/microservice-chart/templates/deployments.yaml
@@ -80,15 +80,12 @@ spec:
         - name: crt-mounter
           securityContext:
             allowPrivilegeEscalation: false
-          image: alpine:latest
+          image: alpine:3.16.1@sha256:9b2a28eb47540823042a2ba401386845089bb7b62a9637d55816132c4c3c36eb
           command: ['tail', '-f', '/dev/null']
           resources:
-            requests:
+            limits:
               memory: 16Mi
               cpu: 50m
-            limits:
-              memory: 32Mi
-              cpu: 100m
           volumeMounts:
             - name: secrets-store-inline-crt
               mountPath: "/mnt/secrets-store-crt"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- remove resource request for mounter container
- remove latest tag on alpine and pin version with container sha256

### Motivation and context

HPA uses pod CPU/RAM in his algorithm so mounter container can create unexpected metrics during scaling.
Also the algorithm skip the containers without resource request, so we use this skill to exclude mounter container from autoscaling rules.

Also as security best practice we need to pin alpine version: current latest version is 3.16.1 with his sha256


ref.
- https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
- https://stackoverflow.com/questions/69721405/trying-to-understand-the-meaning-of-averageutilization-in-kubernetes-autoscaling

### Type of changes

- [ ] Add new feature
- [x] Update existing feature
- [ ] Remove existing feature

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
