### PR TITLE
feat: Add prometheus service monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,26 @@ To update the page content, use `bin/publish`.
 
 ## Breaking changes
 
+### v2.2.0
+
+*serviceMonitor*:
+
+Now create service monitor for send metrics to prometheus
+```yaml
+  serviceMonitor:
+    create: true
+    endpoints:
+      - interval: 10s #micrometer
+        targetPort: 9092
+        path: /
+      - interval: 10s #cinnamon
+        targetPort: 9091
+        path: /metrics
+```
+
+
+## Breaking changes
+
 ### v2.1.0
 
 *fileShare*:

--- a/charts/microservice-chart/templates/beta-deployment.yaml
+++ b/charts/microservice-chart/templates/beta-deployment.yaml
@@ -206,6 +206,8 @@ spec:
                 path: {{ $key }}
           {{- end }}
         {{- end }}
+      restartPolicy: {{ .Values.restartPolicy }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -218,4 +220,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/microservice-chart/templates/beta-service-monitor.yaml
+++ b/charts/microservice-chart/templates/beta-service-monitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.canaryDelivery.create .Values.canaryDelivery.serviceMonitor.create -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "microservice-chart.fullnameCanaryDelivery" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    release: prometheus
+    {{- include "microservice-chart.labelsCanaryDelivery" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "microservice-chart.labelsCanaryDelivery" . | nindent 6 }}
+  endpoints:
+    {{- range  $k, $v := .Values.canaryDelivery.serviceMonitor.endpoints }}
+    - interval: {{ $v.interval }}
+      targetPort: {{ $v.targetPort }}
+      path: {{ $v.path }}
+    {{- end }}
+{{- end }}
+
+---

--- a/charts/microservice-chart/templates/deployments.yaml
+++ b/charts/microservice-chart/templates/deployments.yaml
@@ -143,6 +143,8 @@ spec:
                 path: {{ $key }}
           {{- end }}
         {{- end }}
+      restartPolicy: {{ .Values.restartPolicy }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -155,4 +157,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/microservice-chart/templates/service-monitor.yaml
+++ b/charts/microservice-chart/templates/service-monitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.serviceMonitor.create -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "microservice-chart.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    release: prometheus
+    {{- include "microservice-chart.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "microservice-chart.selectorLabels" . | nindent 6 }}
+  endpoints:
+    {{- range  $k, $v := .Values.serviceMonitor.endpoints }}
+    - interval: {{ $v.interval }}
+      targetPort: {{ $v.targetPort }}
+      path: {{ $v.path }}
+    {{- end }}
+{{- end }}
+
+---

--- a/charts/microservice-chart/values.yaml
+++ b/charts/microservice-chart/values.yaml
@@ -65,6 +65,10 @@ canaryDelivery:
   secretProviderClass:
     # -- (bool) Beta/create or not the secret provider class manifest
     create: true
+  serviceMonitor:
+    # -- (bool) Create or not the service monitor
+    create: false
+    endpoints: [ ]
 
 #
 # Deployment
@@ -168,6 +172,14 @@ tolerations: []
 # -- Pod labels affinity
 affinity: {}
 
+restartPolicy: "Always"
+terminationGracePeriodSeconds: 30
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 25%
+    maxSurge: 25%
+
 #
 # Network
 #
@@ -250,3 +262,8 @@ serviceAccount:
   create: false
   annotations: {}
   name: ""
+
+serviceMonitor:
+  # -- (bool) Create or not the service monitor
+  create: false
+  endpoints: []


### PR DESCRIPTION
###  List of changes
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

* add service monitor
* add strategy
* add restartPolicy
* add terminationGracePeiods

<!--- Describe your changes in detail -->

### Motivation and context

Now create service monitor for send metrics to prometheus
```yaml
  serviceMonitor:
    create: true
    endpoints:
      - interval: 10s #micrometer
        targetPort: 9092
        path: /
      - interval: 10s #cinnamon
        targetPort: 9091
        path: /metrics
```

### Type of changes

- [x] Add new feature
- [ ] Update existing feature
- [ ] Remove existing feature

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
