### PR TITLE
feat: [PAYMCLOUD-270] Update ServiceMonitor API version for managed prometheus migration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,26 @@
 # CHANGELOG
 
+## v7.4.0
+
+Add conditional API version in ServiceMonitor with azmonitoring.coreos.com/v1 and monitoring.coreos.com/v1.
+Add serviceMonitor.prometheusManaged flag to enable new API.
+
+## v7.3.1
+
+fix: pre-commit run with different options depending on branch.
+
+v7.3.0
+
+feat: Updated lint and pre-commit actions.
+fix(Deployment): forceRedeploy value inside deployment.
+
 ## v7.2.0
 
-Added `revisionHistoryLimit` in Deployment to allow to configure the number of revisions/replica set to have has history
+Added `revisionHistoryLimit` in Deployment to allow to configure the number of revisions/replica set to have has history.
 
 ## v7.1.1
 
-Tests suite updated
+Tests suite updated.
 
 ## v7.1.0
 

--- a/README.md
+++ b/README.md
@@ -429,6 +429,38 @@ postman-test:
   envVariablesFile: "arc_DEV.postman_environment.json" #inside azdo secure files
 ```
 
+### `Service Monitors`
+
+The **Service Monitor** allows you to configure and send metrics from your 
+application to **Prometheus**, both locally hosted and managed, 
+using this new version of the configuration module. This feature is essential 
+for monitoring application health and gaining real-time insights into its performance.
+
+```yaml
+serviceMonitor:
+  create: true
+  endpoints:
+    - interval: 10s
+      targetPort: 9092
+      path: /
+    - interval: 10s
+      targetPort: 9091
+      path: /metrics
+  promethuesManaged: true
+```
+
+1. `create: true`
+Enables automatic creation of a dedicated Service Monitor for Prometheus.
+2. **`endpoints`**
+A list of endpoints defined to allow Prometheus to scrape metrics from the monitoring targets.
+    - **`interval`**: Specifies how frequently Prometheus should scrape metrics from the endpoint (e.g., every 10 seconds).
+    - **`targetPort`**: Sets the port Prometheus should connect to in order to access metrics.
+    - **`path`**: Defines the HTTP path where metrics are exposed — e.g., `/` for general information and `/metrics` for specific monitoring data.
+3. `promethuesManaged: true`
+Enables integration with a **managed Prometheus system**. This option is useful when using Prometheus as a managed service (e.g., in cloud environments), allowing the Service Monitor to automatically adjust to such setups.
+
+### More info
+
 See [README/Postman tests](charts/microservice-chart/README.md) to understand how to use the values.
 
 ## Advanced

--- a/charts/microservice-chart/Chart.yaml
+++ b/charts/microservice-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: microservice-chart
 description: A Helm chart for PagoPA microservice
 type: application
-version: 7.3.1
+version: 7.4.0
 appVersion: "0.0.0"

--- a/charts/microservice-chart/README.md
+++ b/charts/microservice-chart/README.md
@@ -1,6 +1,6 @@
 # microservice-chart
 
-![Version: 7.3.1](https://img.shields.io/badge/Version-7.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 7.4.0](https://img.shields.io/badge/Version-7.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm chart for PagoPA microservice
 

--- a/charts/microservice-chart/README.md
+++ b/charts/microservice-chart/README.md
@@ -136,7 +136,7 @@ A Helm chart for PagoPA microservice
 | serviceAccount.name | string | `""` | Service account name, this service account already exists |
 | serviceMonitor.create | bool | `false` | Create or not the service monitor |
 | serviceMonitor.endpoints | list | `[]` |  |
-| serviceMonitor.prometheusManaged | bool | `false` |  |
+| serviceMonitor.prometheusManaged | bool | `false` | Enable the compatibility with Azure Prometheus Managed |
 | sidecars | list | `[]` | Sidecars, each object has exactly the same schema as a Pod, except it does not have an apiVersion or kind |
 | startupProbe | object | {} | startupProbe |
 | startupProbe.exec | object | `{"command":[]}` | exec options |

--- a/charts/microservice-chart/README.md
+++ b/charts/microservice-chart/README.md
@@ -136,6 +136,7 @@ A Helm chart for PagoPA microservice
 | serviceAccount.name | string | `""` | Service account name, this service account already exists |
 | serviceMonitor.create | bool | `false` | Create or not the service monitor |
 | serviceMonitor.endpoints | list | `[]` |  |
+| serviceMonitor.prometheusManaged | bool | `false` |  |
 | sidecars | list | `[]` | Sidecars, each object has exactly the same schema as a Pod, except it does not have an apiVersion or kind |
 | startupProbe | object | {} | startupProbe |
 | startupProbe.exec | object | `{"command":[]}` | exec options |

--- a/charts/microservice-chart/templates/service-monitor.yaml
+++ b/charts/microservice-chart/templates/service-monitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.serviceMonitor.create -}}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: azmonitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "microservice-chart.fullname" . }}

--- a/charts/microservice-chart/templates/service-monitor.yaml
+++ b/charts/microservice-chart/templates/service-monitor.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.serviceMonitor.create -}}
+{{- if .Values.serviceMonitor.prometheusManaged -}}
 apiVersion: azmonitoring.coreos.com/v1
+{{- else }}
+apiVersion: monitoring.coreos.com/v1
+{{- end }}
 kind: ServiceMonitor
 metadata:
   name: {{ include "microservice-chart.fullname" . }}

--- a/charts/microservice-chart/values.yaml
+++ b/charts/microservice-chart/values.yaml
@@ -317,6 +317,7 @@ serviceMonitor:
   # -- (bool) Create or not the service monitor
   create: false
   endpoints: []
+  prometheusManaged: false
 
 service:
   # -- (bool) create the service manifest

--- a/charts/microservice-chart/values.yaml
+++ b/charts/microservice-chart/values.yaml
@@ -317,6 +317,7 @@ serviceMonitor:
   # -- (bool) Create or not the service monitor
   create: false
   endpoints: []
+  # -- (bool) Enable the compatibility with Azure Prometheus Managed
   prometheusManaged: false
 
 service:


### PR DESCRIPTION
### Description

Updated the API version in the `ServiceMonitor` from `monitoring.coreos.com/v1` to `azmonitoring.coreos.com/v1` to ensure compatibility with the updated monitoring system. No other functionality was altered.

### List of changes

- Add conditional API version in `ServiceMonitor` with `azmonitoring.coreos.com/v1` and `monitoring.coreos.com/v1`.
- Add `serviceMonitor.prometheusManaged` flag to enable new API.

### Motivation and context

This change is required to maintain compatibility with managed prometheus to the monitoring system.

### Type of changes

- [x] Update existing feature

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

No additional information.