### PR TITLE
fix: [PAYMCLOUD-923] adjust HAProxy Ingress configuration for java app

### DIFF
--- a/charts/microservice-chart/README.md
+++ b/charts/microservice-chart/README.md
@@ -1,6 +1,6 @@
 # microservice-chart
 
-![Version: 8.3.0](https://img.shields.io/badge/Version-8.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 8.4.0](https://img.shields.io/badge/Version-8.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm chart for PagoPA microservice
 
@@ -59,12 +59,12 @@ A Helm chart for PagoPA microservice
 | ingress.annotations | map | `{}` | custom annotations for ingress |
 | ingress.create | bool | `false` | Create or not the ingress manifest |
 | ingress.forceSslRedirect | bool | `true` | if force ssl redirect is enabled |
-| ingress.haproxy | object | `{"annotations":{},"create":false,"host":"","path":"/please-put-a-path","rewriteTarget":"/"}` | HAProxy Ingress configuration |
+| ingress.haproxy | object | `{"annotations":{},"create":false,"host":"","path":"/please-put-a-path","rewriteTarget":""}` | HAProxy Ingress configuration |
 | ingress.haproxy.annotations | map | `{}` | custom annotations for HAProxy ingress |
 | ingress.haproxy.create | bool | `false` | Create or not the HAProxy ingress manifest |
 | ingress.haproxy.host | string | `""` | Hostname for the ingress like <https://idpay.pagopa.it> |
 | ingress.haproxy.path | string | `"/please-put-a-path"` | Path where the application can response like: `/app(/|$)(.*)` |
-| ingress.haproxy.rewriteTarget | string | `"/"` | the rewrite target for ingress |
+| ingress.haproxy.rewriteTarget | string | `""` | the rewrite target for ingress |
 | ingress.host | string | `""` | Hostname for the ingress like <https://idpay.pagopa.it> |
 | ingress.path | string | `"/please-put-a-path"` | Path where the application can response like: `/app(/|$)(.*)` |
 | ingress.pathType | string | `"ImplementationSpecific"` | pathType |

--- a/charts/microservice-chart/templates/ingress-haproxy.yml
+++ b/charts/microservice-chart/templates/ingress-haproxy.yml
@@ -8,11 +8,7 @@ metadata:
     kubernetes.io/ingress.class: haproxy
     haproxy.org/ssl-redirect: {{ .Values.ingress.forceSslRedirect | quote }}
     {{- if and .Values.ingress.haproxy.path .Values.ingress.haproxy.rewriteTarget (ne .Values.ingress.haproxy.path .Values.ingress.haproxy.rewriteTarget) }}
-    haproxy.org/request-set-header: |
-      X-Forwarded-Prefix {{ trimSuffix "/" .Values.ingress.haproxy.path }}
-      X-Forwarded-Host {{ .Values.ingress.haproxy.host }}
-      X-Forwarded-Proto https
-      X-Forwarded-Port 443
+    haproxy.org/path-rewrite: {{ printf "^%s/(.*) %s" .Values.ingress.haproxy.path .Values.ingress.haproxy.rewriteTarget }}
     {{- end }}
     {{- with .Values.ingress.haproxy.annotations }}
 {{ toYaml . | indent 4 }}
@@ -31,14 +27,14 @@ spec:
                 port:
                   number: {{ .Values.ingress.servicePort }}
             path: {{ .Values.ingress.haproxy.path }}
-            pathType: ImplementationSpecific
+            pathType: {{ .Values.ingress.pathType }}
           - backend:
               service:
                 name: {{ include "microservice-chart.fullname" . }}-canary-wt
                 port:
                   number: {{ .Values.ingress.servicePort }}
             path: {{ .Values.ingress.haproxy.path }}
-            pathType: ImplementationSpecific
+            pathType: {{ .Values.ingress.pathType }}
           {{- else }}
           - backend:
               service:
@@ -46,7 +42,7 @@ spec:
                 port:
                   number: {{ .Values.ingress.servicePort }}
             path: {{ .Values.ingress.haproxy.path }}
-            pathType: ImplementationSpecific
+            pathType: {{ .Values.ingress.pathType }}
           {{- end }}
           {{- end }}
           - backend:

--- a/charts/microservice-chart/values.yaml
+++ b/charts/microservice-chart/values.yaml
@@ -375,7 +375,7 @@ ingress:
     # -- Path where the application can response like: `/app(/|$)(.*)`
     path: "/please-put-a-path"
     # -- the rewrite target for ingress
-    rewriteTarget: /
+    rewriteTarget: ""
     # -- (map) custom annotations for HAProxy ingress
     annotations: {}
 

--- a/tests/v8-haproxy-ingress-test/helm/Chart.yaml
+++ b/tests/v8-haproxy-ingress-test/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 1.0.0
 appVersion: 1.0.0
 dependencies:
 - name: microservice-chart
-  version: 8.3.0
+  version: 8.4.0
   repository: file://../../../charts/microservice-chart

--- a/tests/v8-haproxy-ingress-test/helm/values-devopslab-dev.yaml
+++ b/tests/v8-haproxy-ingress-test/helm/values-devopslab-dev.yaml
@@ -70,8 +70,7 @@ microservice-chart:
       - 8080
 
   ingress:
-    create: true
-    host: testit.itn.internal.devopslab.pagopa.it
+    create: false
     servicePort: 8080
     forceSslRedirect: true
     path: "/testit/test-haproxy(/|$)(.*)"
@@ -79,8 +78,9 @@ microservice-chart:
     haproxy:
       create: true
       host: haproxy.itn.internal.devopslab.pagopa.it
-      path: "/test-haproxy"
-      rewriteTarget: "/"
+      path: "/test-haproxy/"
+      rewriteTarget: "/1"
+      pathType: Prefix
 
   canaryDelivery:
     create: true


### PR DESCRIPTION
Upgraded `microservice-chart` dependency to version 8.4.0. Modified HAProxy Ingress path and rewriteTarget settings, replaced `request-set-header` with `path-rewrite`, and introduced support for configurable `pathType` in Helm chart templates and values. Updated devopslab-dev configuration to disable ingress creation and refine HAProxy settings.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new feature
- [ ] Update existing feature
- [ ] Remove existing feature

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
