### PR TITLE
fix: [PAYMCLOUD-951] Enhance HAProxy backend annotations and volume mount support

### DIFF
--- a/charts/microservice-chart/README.md
+++ b/charts/microservice-chart/README.md
@@ -1,6 +1,6 @@
 # microservice-chart
 
-![Version: 8.4.0](https://img.shields.io/badge/Version-8.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 8.4.1](https://img.shields.io/badge/Version-8.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm chart for PagoPA microservice
 
@@ -59,8 +59,9 @@ A Helm chart for PagoPA microservice
 | ingress.annotations | map | `{}` | custom annotations for ingress |
 | ingress.create | bool | `false` | Create or not the ingress manifest |
 | ingress.forceSslRedirect | bool | `true` | if force ssl redirect is enabled |
-| ingress.haproxy | object | `{"annotations":{},"create":false,"host":"","path":"/please-put-a-path","rewriteTarget":""}` | HAProxy Ingress configuration |
+| ingress.haproxy | object | `{"annotations":{},"backendAnnotations":{},"create":false,"host":"","path":"/please-put-a-path","rewriteTarget":""}` | HAProxy Ingress configuration |
 | ingress.haproxy.annotations | map | `{}` | custom annotations for HAProxy ingress |
+| ingress.haproxy.backendAnnotations | map | `{}` | annotations applied to backend Services (e.g. haproxy.org/backend-config-snippet for path-rewrite after canary ACL evaluation) |
 | ingress.haproxy.create | bool | `false` | Create or not the HAProxy ingress manifest |
 | ingress.haproxy.host | string | `""` | Hostname for the ingress like <https://idpay.pagopa.it> |
 | ingress.haproxy.path | string | `"/please-put-a-path"` | Path where the application can response like: `/app(/|$)(.*)` |

--- a/charts/microservice-chart/templates/canary-haproxy.yaml
+++ b/charts/microservice-chart/templates/canary-haproxy.yaml
@@ -1,4 +1,9 @@
 {{- if and .Values.ingress.haproxy.create .Values.canaryDelivery.create -}}
+{{- $backendSnippet := "" -}}
+{{- if .Values.ingress.haproxy.backendAnnotations -}}
+{{- else if and .Values.ingress.haproxy.rewriteTarget .Values.ingress.haproxy.path -}}
+{{- $backendSnippet = printf "http-request replace-path ^%s/?(.*) %s" .Values.ingress.haproxy.path .Values.ingress.haproxy.rewriteTarget -}}
+{{- end -}}
 {{- if and .Values.canaryDelivery.ingress.header .Values.canaryDelivery.ingress.weightPercent }}
 apiVersion: v1
 kind: Service
@@ -9,6 +14,11 @@ metadata:
     {{- include "microservice-chart.labels" . | nindent 4 }}
   annotations:
     haproxy.org/route-acl: {{ printf "hdr(%s) -m str %s" .Values.canaryDelivery.ingress.headerName .Values.canaryDelivery.ingress.headerValue | quote }}
+    {{- if .Values.ingress.haproxy.backendAnnotations }}
+    {{- toYaml .Values.ingress.haproxy.backendAnnotations | nindent 4 }}
+    {{- else if $backendSnippet }}
+    haproxy.org/backend-config-snippet: {{ $backendSnippet | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -32,6 +42,11 @@ metadata:
     {{- include "microservice-chart.labels" . | nindent 4 }}
   annotations:
     haproxy.org/route-acl: {{ printf "rand(100) lt %d" (int .Values.canaryDelivery.ingress.weightPercent) | quote }}
+    {{- if .Values.ingress.haproxy.backendAnnotations }}
+    {{- toYaml .Values.ingress.haproxy.backendAnnotations | nindent 4 }}
+    {{- else if $backendSnippet }}
+    haproxy.org/backend-config-snippet: {{ $backendSnippet | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -55,6 +70,11 @@ metadata:
     {{- include "microservice-chart.labels" . | nindent 4 }}
   annotations:
     haproxy.org/route-acl: {{ printf "hdr(%s) -m str %s" .Values.canaryDelivery.ingress.headerName .Values.canaryDelivery.ingress.headerValue | quote }}
+    {{- if .Values.ingress.haproxy.backendAnnotations }}
+    {{- toYaml .Values.ingress.haproxy.backendAnnotations | nindent 4 }}
+    {{- else if $backendSnippet }}
+    haproxy.org/backend-config-snippet: {{ $backendSnippet | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -78,6 +98,11 @@ metadata:
     {{- include "microservice-chart.labels" . | nindent 4 }}
   annotations:
     haproxy.org/route-acl: {{ printf "rand(100) lt %d" (int .Values.canaryDelivery.ingress.weightPercent) | quote }}
+    {{- if .Values.ingress.haproxy.backendAnnotations }}
+    {{- toYaml .Values.ingress.haproxy.backendAnnotations | nindent 4 }}
+    {{- else if $backendSnippet }}
+    haproxy.org/backend-config-snippet: {{ $backendSnippet | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -178,16 +203,10 @@ spec:
           env:
             {{- range $key, $val := (mergeOverwrite .Values.envConfig .Values.canaryDelivery.envConfig) }}
             - name: {{ $key }}
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "microservice-chart.fullname" $ }}
-                  key: {{ $key }}
+              value: {{ $val | quote }}
             {{- end }}
             - name: CANARY
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "microservice-chart.fullname" . }}
-                  key: CANARY
+              value: "true"
             {{- if .Values.secretProviderClass.create }}
             {{- range $name, $value := (mergeOverwrite .Values.envSecret .Values.canaryDelivery.envSecret) }}
             - name: {{ $name }}
@@ -197,20 +216,49 @@ spec:
                   key: {{ $value }}
             {{- end }}
             {{- end }}
-          {{- if .Values.secretProviderClass.create }}
+          {{- if or .Values.tmpVolumeMount.create .Values.persistentVolumeClaimsMounts.create .Values.secretProviderClass.create }}
           volumeMounts:
+            {{- if .Values.tmpVolumeMount.create }}
+            {{- range $i, $val := .Values.tmpVolumeMount.mounts }}
+            - name: {{ $val.name }}
+              mountPath: {{ $val.mountPath }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.persistentVolumeClaimsMounts.create }}
+            {{- range $i, $val := .Values.persistentVolumeClaimsMounts.mounts }}
+            - name: {{ $val.name }}
+              mountPath: {{ $val.mountPath }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.secretProviderClass.create }}
             - name: secrets-store-inline
               mountPath: "/mnt/secrets-store"
               readOnly: true
+            {{- end }}
           {{- end }}
-      {{- if .Values.secretProviderClass.create }}
+      {{- if or .Values.tmpVolumeMount.create .Values.persistentVolumeClaimsMounts.create .Values.secretProviderClass.create }}
       volumes:
+        {{- if .Values.tmpVolumeMount.create }}
+        {{- range $i, $val := .Values.tmpVolumeMount.mounts }}
+        - name: {{ $val.name }}
+          emptyDir: {}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.persistentVolumeClaimsMounts.create }}
+        {{- range $i, $val := .Values.persistentVolumeClaimsMounts.mounts }}
+        - name: {{ $val.name }}
+          persistentVolumeClaim:
+            claimName: {{ $val.pvcName }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.secretProviderClass.create }}
         - name: secrets-store-inline
           csi:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ include "microservice-chart.fullname" . }}
+        {{- end }}
       {{- end }}
       {{- include "microservice-chart.tolerationsBlock" . | nindent 6 }}
       {{- include "microservice-chart.nodeSelectorBlock" . | nindent 6 }}

--- a/charts/microservice-chart/templates/configmap.yaml
+++ b/charts/microservice-chart/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.envConfig .Values.configMapFromFile .Values.canaryDelivery.create -}}
+{{- if or .Values.envConfig .Values.configMapFromFile (and .Values.canaryDelivery.create (not .Values.ingress.haproxy.create)) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "microservice-chart.labels" . | nindent 4 }}
 data:
-  {{- if .Values.canaryDelivery.create }}
+  {{- if and .Values.canaryDelivery.create (not .Values.ingress.haproxy.create) }}
   CANARY: "true"
   {{- if .Values.envConfig -}}
   {{- toYaml (mergeOverwrite .Values.envConfig .Values.canaryDelivery.envConfig) | nindent 2 }}

--- a/charts/microservice-chart/templates/ingress-haproxy.yml
+++ b/charts/microservice-chart/templates/ingress-haproxy.yml
@@ -7,9 +7,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: haproxy
     haproxy.org/ssl-redirect: {{ .Values.ingress.forceSslRedirect | quote }}
-    {{- if and .Values.ingress.haproxy.path .Values.ingress.haproxy.rewriteTarget (ne .Values.ingress.haproxy.path .Values.ingress.haproxy.rewriteTarget) }}
-    haproxy.org/path-rewrite: {{ printf "^%s/(.*) %s" .Values.ingress.haproxy.path .Values.ingress.haproxy.rewriteTarget }}
-    {{- end }}
     {{- with .Values.ingress.haproxy.annotations }}
 {{ toYaml . | indent 4 }}
     {{- end }}

--- a/charts/microservice-chart/templates/services.yaml
+++ b/charts/microservice-chart/templates/services.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "microservice-chart.labels" . | nindent 4 }}
+  {{- if and .Values.ingress.haproxy.create .Values.ingress.haproxy.backendAnnotations }}
+  annotations:
+    {{- toYaml .Values.ingress.haproxy.backendAnnotations | nindent 4 }}
+  {{- else if and .Values.ingress.haproxy.create .Values.ingress.haproxy.rewriteTarget }}
+  annotations:
+    haproxy.org/backend-config-snippet: {{ printf "http-request replace-path ^%s/?(.*) %s" .Values.ingress.haproxy.path .Values.ingress.haproxy.rewriteTarget | quote }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/microservice-chart/values.yaml
+++ b/charts/microservice-chart/values.yaml
@@ -378,6 +378,8 @@ ingress:
     rewriteTarget: ""
     # -- (map) custom annotations for HAProxy ingress
     annotations: {}
+    # -- (map) annotations applied to backend Services (e.g. haproxy.org/backend-config-snippet for path-rewrite after canary ACL evaluation)
+    backendAnnotations: {}
 
 
 # -- This section allow to configure canary deployment

--- a/tests/v8-haproxy-ingress-test/helm/Chart.yaml
+++ b/tests/v8-haproxy-ingress-test/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 1.0.0
 appVersion: 1.0.0
 dependencies:
 - name: microservice-chart
-  version: 8.4.0
+  version: 8.4.1
   repository: file://../../../charts/microservice-chart

--- a/tests/v8-haproxy-ingress-test/helm/values-devopslab-dev.yaml
+++ b/tests/v8-haproxy-ingress-test/helm/values-devopslab-dev.yaml
@@ -3,7 +3,7 @@ microservice-chart:
 
   deployment:
     create: true
-    replicas: 3
+    replicas: 1
     topologySpreadConstraints:
       create: true
       useDefaultConfiguration: true
@@ -24,17 +24,17 @@ microservice-chart:
 
   livenessProbe:
     httpGet:
-      path: /
+      path: /status/live
       port: 8080
-    initialDelaySeconds: 5
+    initialDelaySeconds: 30
     failureThreshold: 6
     periodSeconds: 10
 
   readinessProbe:
     httpGet:
-      path: /
+      path: /status/ready
       port: 8080
-    initialDelaySeconds: 5
+    initialDelaySeconds: 30
     failureThreshold: 6
     periodSeconds: 10
 
@@ -43,6 +43,8 @@ microservice-chart:
     MY_APP_COLOR: "green"
     MY_MANDATORY_VALUE: "mandatory"
     BASE_PATH: "/test-haproxy"
+    TMPDIR: "/tmp"
+    JAVA_TOOL_OPTIONS: "-Djava.io.tmpdir=/tmp"
 
   tmpVolumeMount:
     create: true
@@ -53,9 +55,17 @@ microservice-chart:
         mountPath: /app/logs
 
   image:
-    repository: ghcr.io/mendhak/http-https-echo
-    tag: "31"
+    repository: ghcr.io/pagopa/devops-java-springboot-color
+    tag: "latest"
     pullPolicy: Always
+
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "300m"
+    limits:
+      memory: "1Gi"
+      cpu: "600m"
 
   keyvault:
     name: "dvopla-d-itn-testit-kv"
@@ -78,9 +88,8 @@ microservice-chart:
     haproxy:
       create: true
       host: haproxy.itn.internal.devopslab.pagopa.it
-      path: "/test-haproxy/"
-      rewriteTarget: "/1"
-      pathType: Prefix
+      path: "/test-haproxy"
+      rewriteTarget: "/\\1"
 
   canaryDelivery:
     create: true
@@ -90,11 +99,15 @@ microservice-chart:
       headerValue: enabled
       weightPercent: 20
     image:
-      repository: ghcr.io/mendhak/http-https-echo
-      tag: "32"
+      repository: ghcr.io/pagopa/devops-java-springboot-color
+      tag: "latest"
     envConfig:
+      APP: canary
       FOO: "bar"
+      MY_APP_COLOR: "blue"
       MY_MANDATORY_VALUE: "mandatory"
+      TMPDIR: "/tmp"
+      JAVA_TOOL_OPTIONS: "-Djava.io.tmpdir=/tmp"
     envSecret:
       MY_KV_SECRET: dvopla-d-itn-dev-aks-apiserver-url
       TEST: test


### PR DESCRIPTION
### List of changes

- Added support for `backendAnnotations` to enable path rewrite logic after canary ACL evaluation.
- Enhanced volume mount configurations to support both temporary and persistent volumes.
- Updated default liveness and readiness probe paths.
- Refined deployment configurations for `devopslab`.
- Incremented `microservice-chart` to version 8.4.1.

### Motivation and context

This change improves the flexibility and functionality of HAProxy configurations for various use cases. It simplifies deployment configuration management and ensures consistency in adherence to best practices.

### Type of changes

- [x] Add new feature
- [ ] Update existing feature
- [ ] Remove existing feature

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

None.